### PR TITLE
Add end point to fetch reconstruction batch to process.

### DIFF
--- a/migrations/20201205154738_alter_reconstructions_table_add_reconstruction_file_column.ts
+++ b/migrations/20201205154738_alter_reconstructions_table_add_reconstruction_file_column.ts
@@ -1,0 +1,19 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table(
+    'reconstructions',
+    (table: Knex.AlterTableBuilder) => {
+      table.string('reconstruction_file').nullable();
+    }
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table(
+    'reconstructions',
+    (table: Knex.AlterTableBuilder) => {
+      table.dropColumn('reconstruction_file');
+    }
+  );
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ import { SortOrder } from './domain/PaginationQuery';
 import GoogleAPIConfig from './domain/GoogleAPIConfig';
 import PaginationConfig from './domain/PaginationConfig';
 import { AvailableStorageAPI } from './domain/StorageAPI';
+import SupportedMimeTypes from './domain/SupportedMimeTypes';
 
 interface Config {
   port: number;
@@ -22,13 +23,13 @@ interface Config {
   accessTokenSecret: string;
   refreshTokenSecret: string;
   multerConfig: MulterOptions;
-  supportedMimeTypes: string[];
   swaggerConfig: SwaggerOptions;
   accessTokenConfig: SignOptions;
   storageAPI: AvailableStorageAPI;
   refreshTokenConfig: SignOptions;
   googleAPIConfig?: GoogleAPIConfig;
   paginationConfig: PaginationConfig;
+  supportedMimeTypes: SupportedMimeTypes;
 }
 
 const config: Config = {
@@ -70,7 +71,10 @@ const config: Config = {
       }
     },
   },
-  supportedMimeTypes: ['image/jpeg', 'image/png'],
+  supportedMimeTypes: {
+    image: ['image/jpeg', 'image/png'],
+    reconstruction: ['application/octet-stream'],
+  },
   uploadDirectory: resolve(__dirname, '../uploads'),
   multerConfig: {
     dest: resolve(__dirname, '../uploads', 'tmp'),

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,7 +73,7 @@ const config: Config = {
   },
   supportedMimeTypes: {
     image: ['image/jpeg', 'image/png'],
-    reconstruction: ['application/octet-stream'],
+    reconstruction: ['text/plain'],
   },
   uploadDirectory: resolve(__dirname, '../uploads'),
   multerConfig: {

--- a/src/controllers/reconstructions.ts
+++ b/src/controllers/reconstructions.ts
@@ -78,6 +78,38 @@ export async function reconstruction(
   }
 }
 
+export async function reconstructionBatch(
+  req: Request,
+  res: Response<Reconstruction[]>,
+  next: NextFunction
+) {
+  try {
+    let reconstruction:
+      | Reconstruction[]
+      | undefined = await reconstructionService.fetchReconstructionBatch(
+      +req.params.size || 10
+    );
+
+    if (reconstruction) {
+      res.json(reconstruction);
+      return;
+    }
+
+    next({
+      status: 404,
+      message: 'Reconstructions not found.',
+    });
+  } catch (err) {
+    debug('ERROR: %O', err);
+
+    next({
+      status: 500,
+      message: 'Error occurred while fetching reconstructions.',
+      ...err,
+    });
+  }
+}
+
 export async function userReconstruction(
   req: Request,
   res: Response<PaginatedResult<Reconstruction>>,
@@ -165,4 +197,5 @@ export default {
   create,
   reconstruction,
   userReconstruction,
+  reconstructionBatch,
 };

--- a/src/domain/SupportedMimeTypes.ts
+++ b/src/domain/SupportedMimeTypes.ts
@@ -1,0 +1,6 @@
+export interface SupportedMimeTypes {
+  image: string[];
+  reconstruction: string[];
+}
+
+export default SupportedMimeTypes;

--- a/src/middlewares/uploadImage.ts
+++ b/src/middlewares/uploadImage.ts
@@ -2,6 +2,7 @@ import Debug, { Debugger } from 'debug';
 import { NextFunction, Request, Response } from 'express';
 import { ParamsDictionary, Query } from 'express-serve-static-core';
 
+import config from '../config';
 import Image from '../models/Image';
 import { upload } from '../utils/uploads';
 import imageService from '../services/images';
@@ -12,9 +13,9 @@ import {
   ValidationErrorResponse,
 } from '../domain/validations';
 
-const debug: Debugger = Debug('threedify:services:uploadImage');
+const debug: Debugger = Debug('threedify:middleware:uploadImage');
 
-export interface RequestWithFiles<
+export interface RequestWithImages<
   P = ParamsDictionary,
   ResBody = any,
   ReqBody = any,
@@ -24,21 +25,21 @@ export interface RequestWithFiles<
   fileValidationErrors: ValidationErrorItem[];
 }
 
-export type AuthRequestWithFiles<
+export type AuthRequestWithImages<
   P = ParamsDictionary,
   ResBody = any,
   ReqBody = any,
   ReqQuery = Query
 > = AuthenticatedRequest<P, ResBody, ReqBody, ReqQuery> &
-  RequestWithFiles<P, ResBody, ReqBody, ReqQuery>;
+  RequestWithImages<P, ResBody, ReqBody, ReqQuery>;
 
 async function uploadImage(
   file: Express.Multer.File,
   key: string,
-  authReq: AuthRequestWithFiles
+  authReq: AuthRequestWithImages
 ) {
-  debug('Uploading file: %s', file.originalname);
-  const fileName: string = await upload(file);
+  debug('Uploading image: %s', file.originalname);
+  const fileName: string = await upload(file, config.supportedMimeTypes.image);
 
   authReq.images = authReq.images || [];
   authReq.fileValidationErrors = authReq.fileValidationErrors || [];
@@ -72,7 +73,7 @@ export function uploadSingleImage(key: string) {
       res: Response<ValidationErrorResponse>,
       next: NextFunction
     ) => {
-      const authReq: AuthRequestWithFiles = req as AuthRequestWithFiles;
+      const authReq: AuthRequestWithImages = req as AuthRequestWithImages;
       try {
         debug('Uploading file for: %s', key);
         const file: Express.Multer.File = req.file;
@@ -97,7 +98,7 @@ export function uploadSingleImage(key: string) {
           errors: [
             {
               [key]: {
-                message: 'Image file not uploaded.',
+                message: 'Image not uploaded.',
               },
             },
           ],
@@ -106,7 +107,7 @@ export function uploadSingleImage(key: string) {
         debug('%O', err);
         next({
           status: 500,
-          message: 'Error occurred while uploading file.',
+          message: 'Error occurred while uploading image.',
           err: err,
         });
       }
@@ -122,7 +123,7 @@ export function uploadImages(key: string) {
       res: Response<ValidationErrorResponse>,
       next: NextFunction
     ) => {
-      const authReq: AuthRequestWithFiles = req as AuthRequestWithFiles;
+      const authReq: AuthRequestWithImages = req as AuthRequestWithImages;
       try {
         debug('Uploading files for: %s', key);
         if (req.files.length > 0) {
@@ -146,7 +147,7 @@ export function uploadImages(key: string) {
           errors: [
             {
               [key]: {
-                message: 'Image files not uploaded.',
+                message: 'Images not uploaded.',
               },
             },
           ],
@@ -155,7 +156,7 @@ export function uploadImages(key: string) {
         debug('%O', err);
         next({
           status: 500,
-          message: 'Error occurred while uploading file.',
+          message: 'Error occurred while uploading image.',
           err: err,
         });
       }

--- a/src/middlewares/uploadReconstruction.ts
+++ b/src/middlewares/uploadReconstruction.ts
@@ -1,0 +1,112 @@
+import Debug, { Debugger } from 'debug';
+import { NextFunction, Request, Response } from 'express';
+import { ParamsDictionary, Query } from 'express-serve-static-core';
+
+import config from '../config';
+import { single } from '../utils/multer';
+import { upload } from '../utils/uploads';
+import { AuthenticatedRequest } from './authenticate';
+import {
+  ValidationErrorItem,
+  ValidationErrorResponse,
+} from '../domain/validations';
+
+const debug: Debugger = Debug('threedify:middleware:uploadImage');
+
+export interface RequestWithReconstructionFile<
+  P = ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = Query
+> extends Request<P, ResBody, ReqBody, ReqQuery> {
+  reconstructionFileName: string;
+  fileValidationErrors: ValidationErrorItem[];
+}
+
+export type AuthRequestWithReconstructionFile<
+  P = ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = Query
+> = AuthenticatedRequest<P, ResBody, ReqBody, ReqQuery> &
+  RequestWithReconstructionFile<P, ResBody, ReqBody, ReqQuery>;
+
+async function uploadFile(
+  file: Express.Multer.File,
+  key: string,
+  authReq: AuthRequestWithReconstructionFile
+) {
+  debug('Uploading reconstruction: %s, %s', file.originalname, file.mimetype);
+  const fileName: string = await upload(
+    file,
+    config.supportedMimeTypes.reconstruction
+  );
+
+  authReq.fileValidationErrors = authReq.fileValidationErrors || [];
+
+  if (fileName) {
+    authReq.reconstructionFileName = fileName;
+  } else {
+    debug('File validation failed.');
+    authReq.fileValidationErrors.push({
+      [key]: {
+        value: { filename: file.originalname, mimetype: file.mimetype },
+        message: "Uploaded file isn't a valid reconstruction file.",
+      },
+    });
+  }
+}
+
+export function uploadReconstruction(key: string) {
+  return [
+    single(key),
+    async (
+      req: Request,
+      res: Response<ValidationErrorResponse>,
+      next: NextFunction
+    ) => {
+      const authReq: AuthRequestWithReconstructionFile = req as AuthRequestWithReconstructionFile;
+      try {
+        debug('Uploading file for: %s', key);
+        const file: Express.Multer.File = req.file;
+
+        if (file) {
+          await uploadFile(file, key, authReq);
+
+          if (authReq.fileValidationErrors.length === 1) {
+            res.status(422);
+            res.json({
+              errors: authReq.fileValidationErrors,
+            });
+            return;
+          }
+
+          next();
+          return;
+        }
+
+        res.status(422);
+        res.json({
+          errors: [
+            {
+              [key]: {
+                message: 'Reconstruction file not uploaded.',
+              },
+            },
+          ],
+        });
+      } catch (err) {
+        debug('%O', err);
+        next({
+          status: 500,
+          message: 'Error occurred while uploading reconstruction file.',
+          err: err,
+        });
+      }
+    },
+  ];
+}
+
+export default {
+  uploadReconstruction,
+};

--- a/src/middlewares/uploadReconstruction.ts
+++ b/src/middlewares/uploadReconstruction.ts
@@ -5,7 +5,7 @@ import { ParamsDictionary, Query } from 'express-serve-static-core';
 import config from '../config';
 import { single } from '../utils/multer';
 import { upload } from '../utils/uploads';
-import { AuthenticatedRequest } from './authenticate';
+import { AuthenticatedRequest } from './authenticateUser';
 import {
   ValidationErrorItem,
   ValidationErrorResponse,

--- a/src/models/BaseModel.ts
+++ b/src/models/BaseModel.ts
@@ -1,0 +1,9 @@
+import { Model } from 'objection';
+
+export class BaseModel extends Model {
+  static get filters(): string[] {
+    return [];
+  }
+}
+
+export default BaseModel;

--- a/src/models/Image.ts
+++ b/src/models/Image.ts
@@ -1,5 +1,5 @@
-import { Model } from 'objection';
 import User from './User';
+import BaseModel from './BaseModel';
 
 const TABLE_NAME: string = 'images';
 
@@ -48,7 +48,7 @@ const TABLE_NAME: string = 'images';
  *            items:
  *              $ref: '#/components/schemas/Image'
  */
-export class Image extends Model {
+export class Image extends BaseModel {
   id!: number;
   fileName!: string;
   mimetype!: string;
@@ -66,7 +66,7 @@ export class Image extends Model {
   static get relationMappings() {
     return {
       uploadedByUser: {
-        relation: Model.BelongsToOneRelation,
+        relation: BaseModel.BelongsToOneRelation,
         modelClass: User,
         join: {
           from: 'images.uploadedBy',

--- a/src/models/Token.ts
+++ b/src/models/Token.ts
@@ -1,10 +1,9 @@
-import { Model } from 'objection';
-
 import User from './User';
+import BaseModel from './BaseModel';
 
 const TABLE_NAME: string = 'tokens';
 
-export class Token extends Model {
+export class Token extends BaseModel {
   id!: number;
   userId!: number;
   accessToken!: string;
@@ -22,7 +21,7 @@ export class Token extends Model {
   static get relationMappings() {
     return {
       user: {
-        relation: Model.BelongsToOneRelation,
+        relation: BaseModel.BelongsToOneRelation,
         modelClass: User,
         join: {
           from: 'tokens.userId',

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,4 +1,6 @@
-import { Model, QueryBuilder } from 'objection';
+import { QueryBuilder } from 'objection';
+
+import BaseModel from './BaseModel';
 
 const TABLE_NAME: string = 'users';
 
@@ -51,7 +53,7 @@ const TABLE_NAME: string = 'users';
  *            items:
  *              $ref: '#/components/schemas/User'
  */
-export class User extends Model {
+export class User extends BaseModel {
   id!: number;
   email!: string;
   username!: string;

--- a/src/routers/reconstructions.ts
+++ b/src/routers/reconstructions.ts
@@ -35,7 +35,7 @@ router.get('/', ReconstructionController.index);
  * @swagger
  *
  * /reconstructions/batch:
- *  get:
+ *  put:
  *    description: End point to fetch reconstructions batch for processing.
  *                 Also updates the reconstructions to in progress state.
  *    parameters:
@@ -54,7 +54,7 @@ router.get('/', ReconstructionController.index);
  *      500:
  *        $ref: '#/components/responses/HTTPError'
  */
-router.get('/batch', ReconstructionController.reconstructionBatch);
+router.put('/batch', ReconstructionController.reconstructionBatch);
 
 /**
  * @swagger
@@ -75,6 +75,30 @@ router.get('/batch', ReconstructionController.reconstructionBatch);
  *        $ref: '#/components/responses/HTTPError'
  */
 router.get('/:id', ReconstructionController.reconstruction);
+
+/**
+ * @swagger
+ *
+ * /reconstructions/{id}/failed:
+ *  put:
+ *    description: End point to set reconstruction state to failed. This changes the state to `IN QUEUE`.
+ *    parameters:
+ *      - name: id
+ *        in: path
+ *        description: Id of reconstruction.
+ *    responses:
+ *      200:
+ *        description: OK
+ *        content:
+ *          text/plain:
+ *            schema:
+ *              type: string
+ *      404:
+ *        $ref: '#/components/responses/HTTPError'
+ *      500:
+ *        $ref: '#/components/responses/HTTPError'
+ */
+router.put('/:id/failed', ReconstructionController.reconstructionFailed);
 
 /**
  * @swagger

--- a/src/routers/reconstructions.ts
+++ b/src/routers/reconstructions.ts
@@ -34,6 +34,31 @@ router.get('/', ReconstructionController.index);
 /**
  * @swagger
  *
+ * /reconstructions/batch:
+ *  get:
+ *    description: End point to fetch reconstructions batch for processing.
+ *                 Also updates the reconstructions to in progress state.
+ *    parameters:
+ *      - $ref: '#/components/parameters/size'
+ *    responses:
+ *      200:
+ *        description: A list of queued reconstructions to process.
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: array
+ *              items:
+ *                $ref: '#/components/schemas/Reconstruction'
+ *      404:
+ *        $ref: '#/components/responses/HTTPError'
+ *      500:
+ *        $ref: '#/components/responses/HTTPError'
+ */
+router.get('/batch', ReconstructionController.reconstructionBatch);
+
+/**
+ * @swagger
+ *
  * /reconstructions/{id}:
  *  get:
  *    description: End point to fetch details of a reconstruction.

--- a/src/routers/reconstructions.ts
+++ b/src/routers/reconstructions.ts
@@ -58,6 +58,34 @@ router.get('/:id', ReconstructionController.reconstruction);
 /**
  * @swagger
  *
+ * /reconstructions/{id}/reconstructionFile:
+ *  get:
+ *    description: End point to fetch reconstruction file.
+ *    parameters:
+ *      - name: id
+ *        in: path
+ *        description: Id of reconstruction.
+ *    responses:
+ *      200:
+ *        description: Reconstruction file.
+ *        content:
+ *          application/octet-stream:
+ *            schema:
+ *               type: string
+ *               format: binary
+ *      404:
+ *        $ref: '#/components/responses/HTTPError'
+ *      500:
+ *        $ref: '#/components/responses/HTTPError'
+ */
+router.get(
+  '/:id/reconstructionFile',
+  ReconstructionController.reconstructionFile
+);
+
+/**
+ * @swagger
+ *
  * /reconstructions/create:
  *  post:
  *    description: End point to create new reconstruction.

--- a/src/services/reconstructions.ts
+++ b/src/services/reconstructions.ts
@@ -1,3 +1,4 @@
+import Objection from 'objection';
 import Debug, { Debugger } from 'debug';
 
 import Image from '../models/Image';
@@ -5,6 +6,7 @@ import Reconstruction from '../models/Reconstruction';
 import { applyPagination } from '../utils/pagination';
 import PaginationQuery from '../domain/PaginationQuery';
 import PaginatedResult from '../domain/PaginatedResult';
+import ReconstructionState from '../domain/ReconstructionState';
 
 const debug: Debugger = Debug('threedify:services:reconstructions');
 
@@ -18,6 +20,41 @@ export async function fetchAllReconstructions(
       '[createdByUser(defaultSelect), images.uploadedByUser(defaultSelect)]'
     ),
     query
+  );
+}
+
+export async function fetchReconstructionBatch(
+  size: number
+): Promise<Reconstruction[] | undefined> {
+  return await Reconstruction.transaction(
+    async (trx: Objection.Transaction) => {
+      debug('Fetching reconstructions batch...');
+      const reconstructions:
+        | Reconstruction[]
+        | undefined = await Reconstruction.query(trx)
+        .withGraphFetched('[images]')
+        .context({ sortOrder: 'ASC' })
+        .modify(['orderByCreatedAt', 'inQueue'])
+        .limit(size);
+
+      if (reconstructions?.length > 0) {
+        debug('Updating reconstructions state to in progress...');
+        await Reconstruction.query(trx)
+          .patch({
+            state: ReconstructionState.INPROGRESS,
+            updatedAt: new Date(),
+          })
+          .whereIn(
+            'id',
+            reconstructions.map((recon) => recon.id)
+          );
+
+        return reconstructions.map((recon) => {
+          recon.state = ReconstructionState.INPROGRESS;
+          return recon;
+        });
+      }
+    }
   );
 }
 
@@ -80,5 +117,6 @@ export default {
   insertReconstruction,
   fetchAllReconstructions,
   fetchReconstructionById,
+  fetchReconstructionBatch,
   fetchReconstructionByUserId,
 };

--- a/src/services/reconstructions.ts
+++ b/src/services/reconstructions.ts
@@ -100,6 +100,13 @@ export async function addImages(
     .first();
 }
 
+export async function setState(
+  reconstruction: Reconstruction,
+  state: ReconstructionState
+) {
+  await reconstruction.$query().patch({ state: state });
+}
+
 export async function insertReconstruction(
   reconstruction: Partial<Reconstruction>
 ): Promise<Reconstruction> {
@@ -113,6 +120,7 @@ export async function insertReconstruction(
 }
 
 export default {
+  setState,
   addImages,
   insertReconstruction,
   fetchAllReconstructions,

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -51,12 +51,19 @@ export function getPaginationQuery(query: any): PaginationQuery {
 
 export async function applyPagination<T extends Model>(
   schema: QueryBuilder<T>,
-  query: PaginationQuery
+  query: PaginationQuery,
+  availableFilters?: string[]
 ): Promise<PaginatedResult<T> | undefined> {
+  let availableModelFilters = availableFilters || [];
+
   debug('Applying pagination.');
   const result: Page<T> = await schema
     .context({ sortOrder: query.order, queryString: query.q })
-    .modify(query.filters)
+    .modify(
+      query.filters.filter((filter) => {
+        return availableModelFilters.includes(filter);
+      })
+    )
     .page(query.page - 1, query.size);
 
   if (result.results.length > 0) {

--- a/src/utils/uploads.ts
+++ b/src/utils/uploads.ts
@@ -14,8 +14,11 @@ function getRandomString(): string {
   return randomBytes(20).toString('hex');
 }
 
-export function isFileSupported(mimeType: string): boolean {
-  return config.supportedMimeTypes.includes(mimeType);
+export function isFileSupported(
+  mimeType: string,
+  supportedMimeTypes: string[]
+): boolean {
+  return supportedMimeTypes.includes(mimeType);
 }
 
 export function getUploadDirectory(): string {
@@ -56,12 +59,15 @@ export function cleanUp(tmpFilePath: string) {
   unlinkSync(tmpFilePath);
 }
 
-export async function upload(file: Express.Multer.File): Promise<string> {
+export async function upload(
+  file: Express.Multer.File,
+  supportedMimeTypes: string[]
+): Promise<string> {
   debug('Uploading file.');
   let fileName: string = '';
   let filePath: string = '';
 
-  if (isFileSupported(file.mimetype)) {
+  if (isFileSupported(file.mimetype, supportedMimeTypes)) {
     [fileName, filePath] = await getFileName(file.mimetype);
     await saveFile(file.path, filePath, file.mimetype);
   }


### PR DESCRIPTION
- [x] Add end point (`/reconstruction/batch`) to fetch reconstruction batch to process.
- [x] Add end point (`/reconstruction/{id}/failed`) to set the failed status.
- [x] Add end point (`/reconstruction/{id}/success`) to upload reconstruction output and set the completed status.
- [x] Add end point (`/reconstruction/{id}/reconstructionFile`) to fetch reconstruction output.