### PR TITLE
Add failed state for reconstruction.

### DIFF
--- a/migrations/20210804212547_alter_reconstruction_state_type_add_value_failed.ts
+++ b/migrations/20210804212547_alter_reconstruction_state_type_add_value_failed.ts
@@ -1,0 +1,26 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE TYPE "ReconstructionState_temp" AS ENUM ('INQUEUE', 'INPROGRESS', 'COMPLETED', 'FAILED');
+    ALTER TABLE reconstructions
+      ALTER COLUMN state DROP DEFAULT,
+      ALTER COLUMN state TYPE "ReconstructionState_temp" USING state::text::"ReconstructionState_temp",
+      ALTER COLUMN state SET DEFAULT 'INQUEUE';
+    DROP TYPE IF EXISTS "ReconstructionState";
+    ALTER TYPE "ReconstructionState_temp" RENAME TO "ReconstructionState";
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    UPDATE reconstructions SET state='INQUEUE' WHERE state='FAILED';
+    CREATE TYPE "ReconstructionState_temp" AS ENUM ('INQUEUE', 'INPROGRESS', 'COMPLETED');
+    ALTER TABLE reconstructions
+      ALTER COLUMN state DROP DEFAULT,
+      ALTER COLUMN state TYPE "ReconstructionState_temp" USING state::text::"ReconstructionState_temp",
+      ALTER COLUMN state SET DEFAULT 'INQUEUE';
+    DROP TYPE IF EXISTS "ReconstructionState";
+    ALTER TYPE "ReconstructionState_temp" RENAME TO "ReconstructionState";
+  `);
+}

--- a/src/controllers/reconstructions.ts
+++ b/src/controllers/reconstructions.ts
@@ -103,10 +103,10 @@ export async function reconstructionFailed(
     if (reconstruction) {
       // TODO: Add process logs for the reconstruction and failed state.
 
-      debug('Setting state of reconstruction to in queue.');
+      debug('Setting state of reconstruction to failed.');
       await reconstructionService.setState(
         reconstruction,
-        ReconstructionState.INQUEUE
+        ReconstructionState.FAILED
       );
 
       res.sendStatus(200);

--- a/src/domain/ReconstructionState.ts
+++ b/src/domain/ReconstructionState.ts
@@ -9,12 +9,14 @@
  *         - INQUEUE
  *         - INPROGRESS
  *         - COMPLETED
+ *         - FAILED
  */
 
 export enum ReconstructionState {
   INQUEUE = 'INQUEUE',
   INPROGRESS = 'INPROGRESS',
   COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
 }
 
 export default ReconstructionState;

--- a/src/models/Reconstruction.ts
+++ b/src/models/Reconstruction.ts
@@ -57,6 +57,7 @@ const TABLE_NAME: string = 'reconstructions';
  *          - orderByCreatedAt
  *          - inQueue
  *          - inProgress
+ *          - failed
  *          - completed
  *  responses:
  *    Reconstruction:
@@ -134,6 +135,11 @@ export class Reconstruction extends BaseModel {
 
         builder.where(ref('state'), '=', ReconstructionState.COMPLETED);
       },
+      failed(builder: QueryBuilder<Reconstruction>) {
+        const { ref } = Reconstruction;
+
+        builder.where(ref('state'), '=', ReconstructionState.FAILED);
+      },
       orderByCreatedAt(builder: QueryBuilder<Reconstruction>) {
         const { ref } = Reconstruction;
 
@@ -143,7 +149,14 @@ export class Reconstruction extends BaseModel {
   }
 
   static get filters(): string[] {
-    return ['search', 'inQueue', 'inProgress', 'completed', 'orderByCreatedAt'];
+    return [
+      'search',
+      'inQueue',
+      'inProgress',
+      'completed',
+      'failed',
+      'orderByCreatedAt',
+    ];
   }
 
   static get relationMappings() {

--- a/src/routers/reconstructions.ts
+++ b/src/routers/reconstructions.ts
@@ -166,7 +166,7 @@ router.put('/batch', ReconstructionController.reconstructionBatch);
  *
  * /reconstructions/{id}/failed:
  *  put:
- *    description: End point to set reconstruction state to failed. This changes the state to `IN QUEUE`.
+ *    description: End point to set reconstruction state to failed. This changes the state to `FAILED`.
  *    parameters:
  *      - name: id
  *        in: path


### PR DESCRIPTION
- Add new state `FAILED` in `ReconstructionState`
- Set the state to `FAILED` instead of `IN QUEUE` in `/reconstructions/{id}/failed`